### PR TITLE
Incorporate generic profiling

### DIFF
--- a/ctf/Makefile
+++ b/ctf/Makefile
@@ -21,10 +21,10 @@ test.o: alg_graph.o mst.o test.h test.cxx $(CTFDIR)
 	$(CXX) $(CXXFLAGS) -c test.cxx mst.o alg_graph.o $(INCLUDES)
 
 test_connectivity: alg_graph.o graph_io.o graph_gen.o connectivity.o mst.o test.o test_connectivity.cxx $(CTFDIR) 
-	$(CXX) $(CXXFLAGS) -o test_connectivity test_connectivity.cxx test.o connectivity.o mst.o graph_io.o graph_gen.o alg_graph.o $(INCLUDES) $(LIBS)
+	$(CXX) $(CXXFLAGS) -o test_connectivity test_connectivity.cxx test.o connectivity.o mst.o graph_io.o graph_gen.o alg_graph.o $(INCLUDES) $(LIB_PATH) $(LIBS)
 
 test_mst: alg_graph.o graph_io.o graph_gen.o mst.o test.o test_mst.cxx $(CTFDIR) 
-	$(CXX) $(CXXFLAGS) -o test_mst test_mst.cxx test.o mst.o graph_io.o graph_gen.o alg_graph.o $(INCLUDES) $(LIBS)
+	$(CXX) $(CXXFLAGS) -o test_mst test_mst.cxx test.o mst.o graph_io.o graph_gen.o alg_graph.o $(INCLUDES) $(LIB_PATH) $(LIBS)
 
 clean:
 	rm -f alg_graph.o connectivity.o mst.o graph_gen.o graph_io.o test.o test_connectivity test_mst

--- a/ctf/alg_graph.cxx
+++ b/ctf/alg_graph.cxx
@@ -70,7 +70,7 @@ template int64_t are_vectors_different<int>(CTF::Vector<int> & A, CTF::Vector<in
 // if create_nonleaves=true, computing non-leaf vertices in parent forest
 void shortcut(Vector<int> & p, Vector<int> & q, Vector<int> & rec_p, Vector<int> ** nonleaves, bool create_nonleaves)
 {
-  TAU_START(Unoptimized_shortcut);
+  TAU_FSTART(Unoptimized_shortcut);
   int64_t npairs;
   Pair<int> * loc_pairs;
   if (q.is_sparse){
@@ -84,20 +84,20 @@ void shortcut(Vector<int> & p, Vector<int> & q, Vector<int> & rec_p, Vector<int>
   for (int64_t i=0; i<npairs; i++){
     remote_pairs[i].k = loc_pairs[i].d;
   }
-  TAU_START(Unoptimized_shortcut_rread);
+  TAU_FSTART(Unoptimized_shortcut_rread);
   rec_p.read(npairs, remote_pairs); //obtains rec_p[q[i]]
-  TAU_STOP(Unoptimized_shortcut_rread);
+  TAU_FSTOP(Unoptimized_shortcut_rread);
   for (int64_t i=0; i<npairs; i++){
     loc_pairs[i].d = remote_pairs[i].d; //p[i] = rec_p[q[i]]
   }
   delete [] remote_pairs;
-  TAU_START(Unoptimized_shortcut_write);
+  TAU_FSTART(Unoptimized_shortcut_write);
   p.write(npairs, loc_pairs); //enter data into p[i]
-  TAU_STOP(Unoptimized_shortcut_write);
+  TAU_FSTOP(Unoptimized_shortcut_write);
   
   //prune out leaves
   if (create_nonleaves){
-    TAU_START(Unoptimized_shortcut_pruneleaves);
+    TAU_FSTART(Unoptimized_shortcut_pruneleaves);
     *nonleaves = new Vector<int>(p.len, *p.wrld, *p.sr);
     //set nonleaves[i] = max_j p[j], i.e. set nonleaves[i] = 1 if i has child, i.e. is nonleaf
     for (int64_t i=0; i<npairs; i++){
@@ -108,11 +108,11 @@ void shortcut(Vector<int> & p, Vector<int> & q, Vector<int> & rec_p, Vector<int>
     (*nonleaves)->write(npairs, loc_pairs);
     (*nonleaves)->operator[]("i") = (*nonleaves)->operator[]("i")*p["i"];
     (*nonleaves)->sparsify();
-    TAU_STOP(Unoptimized_shortcut_pruneleaves);
+    TAU_FSTOP(Unoptimized_shortcut_pruneleaves);
   }
    
   delete [] loc_pairs;
-  TAU_STOP(Unoptimized_shortcut);
+  TAU_FSTOP(Unoptimized_shortcut);
 }
 
 // p[i] = rec_p[q[i]]
@@ -124,7 +124,7 @@ void shortcut2(Vector<int> & p, Vector<int> & q, Vector<int> & rec_p, int sc2, W
     return;
   }
 
-  TAU_START(Optimized_shortcut);
+  TAU_FSTART(Optimized_shortcut);
   
   int64_t rec_p_npairs;
   Pair<int> * rec_p_loc_pairs;
@@ -172,9 +172,9 @@ void shortcut2(Vector<int> & p, Vector<int> & q, Vector<int> & rec_p, int sc2, W
       remote_pairs[i].k = q_loc_pairs[nontriv_index].d;
     }
   
-    TAU_START(Optimized_shortcut_read);
+    TAU_FSTART(Optimized_shortcut_read);
     rec_p.read(*loc_nontriv_num, remote_pairs); //obtains rec_p[q[i]]
-    TAU_STOP(Optimized_shortcut_read);
+    TAU_FSTOP(Optimized_shortcut_read);
     for(int64_t i = 0; i < *loc_nontriv_num; i++) {
       nontriv_loc_pairs[i].d = remote_pairs[i].d;
     }
@@ -184,9 +184,9 @@ void shortcut2(Vector<int> & p, Vector<int> & q, Vector<int> & rec_p, int sc2, W
       q_loc_pairs[nontriv_index].d = remote_pairs[i].d; // p[i] = rec_p[q[i]]
     }
  
-    TAU_START(Optimized_shortcut_write); 
+    TAU_FSTART(Optimized_shortcut_write); 
     p.write(*loc_nontriv_num, nontriv_loc_pairs); //enter data into p[i]
-    TAU_STOP(Optimized_shortcut_write); 
+    TAU_FSTOP(Optimized_shortcut_write); 
     
     delete [] remote_pairs;
     delete [] global_roots;
@@ -198,22 +198,22 @@ void shortcut2(Vector<int> & p, Vector<int> & q, Vector<int> & rec_p, int sc2, W
     for (int64_t i=0; i<q_npairs; i++) {
       remote_pairs[i].k = q_loc_pairs[i].d;
     }
-    TAU_START(Unoptimized_shortcut_Orread);
+    TAU_FSTART(Unoptimized_shortcut_Orread);
     rec_p.read(q_npairs, remote_pairs); //obtains rec_p[q[i]]
-    TAU_STOP(Unoptimized_shortcut_Orread);
+    TAU_FSTOP(Unoptimized_shortcut_Orread);
     for (int64_t i=0; i<q_npairs; i++){
       q_loc_pairs[i].d = remote_pairs[i].d; //p[i] = rec_p[q[i]]
     }
-    TAU_START(Unoptimized_shortcut_Owrite);
+    TAU_FSTART(Unoptimized_shortcut_Owrite);
     p.write(q_npairs, q_loc_pairs); //enter data into p[i]
-    TAU_STOP(Unoptimized_shortcut_Owrite);
+    TAU_FSTOP(Unoptimized_shortcut_Owrite);
 
     delete [] remote_pairs;
   }
   
   //prune out leaves
   if (create_nonleaves) {
-    TAU_START(Unoptimized_shortcut_Opruneleaves);
+    TAU_FSTART(Unoptimized_shortcut_Opruneleaves);
     *nonleaves = new Vector<int>(p.len, *p.wrld, *p.sr); //set nonleaves[i] = max_j p[j], i.e. set nonleaves[i] = 1 if i has child, i.e. is nonleaf
     for (int64_t i=0; i<q_npairs; i++){
       q_loc_pairs[i].k = q_loc_pairs[i].d;
@@ -223,9 +223,9 @@ void shortcut2(Vector<int> & p, Vector<int> & q, Vector<int> & rec_p, int sc2, W
     (*nonleaves)->write(q_npairs, q_loc_pairs);
     (*nonleaves)->operator[]("i") = (*nonleaves)->operator[]("i")*p["i"];
     (*nonleaves)->sparsify();
-    TAU_STOP(Unoptimized_shortcut_Opruneleaves);
+    TAU_FSTOP(Unoptimized_shortcut_Opruneleaves);
   }
-  TAU_STOP(Optimized_shortcut);
+  TAU_FSTOP(Optimized_shortcut);
 
   if (delete_p)
     delete [] q_loc_pairs;
@@ -310,7 +310,7 @@ void create_nontriv_loc_indices(int64_t *& nontriv_loc_indices, int64_t * loc_no
 // return B where B[i,j] = A[p[i],p[j]], or if P is P[i,j] = p[i], compute B = P^T A P
 template<typename T>
 Matrix<T>* PTAP(Matrix<T>* A, Vector<int>* p){
-  TAU_START(CONNECTIVITY_PTAP);
+  TAU_FSTART(CONNECTIVITY_PTAP);
   int np = p->wrld->np;
   int64_t n = p->len;
   Pair<int> * pprs;
@@ -347,7 +347,7 @@ Matrix<T>* PTAP(Matrix<T>* A, Vector<int>* p){
   Matrix<T> * PTAP = new Matrix<T>(n, n, SP*(A->is_sparse), *A->wrld, *A->sr);
   PTAP->write(nprs, A_prs);
   delete [] A_prs;
-  TAU_STOP(CONNECTIVITY_PTAP);
+  TAU_FSTOP(CONNECTIVITY_PTAP);
   return PTAP;
 }
 template Matrix<int>* PTAP<int>(Matrix<int>* A, Vector<int>* p);

--- a/ctf/alg_graph.cxx
+++ b/ctf/alg_graph.cxx
@@ -70,8 +70,7 @@ template int64_t are_vectors_different<int>(CTF::Vector<int> & A, CTF::Vector<in
 // if create_nonleaves=true, computing non-leaf vertices in parent forest
 void shortcut(Vector<int> & p, Vector<int> & q, Vector<int> & rec_p, Vector<int> ** nonleaves, bool create_nonleaves)
 {
-  Timer t_shortcut("Unoptimized_shortcut");
-  t_shortcut.start();
+  TAU_START(Unoptimized_shortcut);
   int64_t npairs;
   Pair<int> * loc_pairs;
   if (q.is_sparse){
@@ -85,23 +84,20 @@ void shortcut(Vector<int> & p, Vector<int> & q, Vector<int> & rec_p, Vector<int>
   for (int64_t i=0; i<npairs; i++){
     remote_pairs[i].k = loc_pairs[i].d;
   }
-  Timer t_shortcut_read("Unoptimized_shortcut_rread");
-  t_shortcut_read.start();
+  TAU_START(Unoptimized_shortcut_rread);
   rec_p.read(npairs, remote_pairs); //obtains rec_p[q[i]]
-  t_shortcut_read.stop();
+  TAU_STOP(Unoptimized_shortcut_rread);
   for (int64_t i=0; i<npairs; i++){
     loc_pairs[i].d = remote_pairs[i].d; //p[i] = rec_p[q[i]]
   }
   delete [] remote_pairs;
-  Timer t_shortcut_write("Unoptimized_shortcut_write");
-  t_shortcut_write.start();
+  TAU_START(Unoptimized_shortcut_write);
   p.write(npairs, loc_pairs); //enter data into p[i]
-  t_shortcut_write.stop();
+  TAU_STOP(Unoptimized_shortcut_write);
   
   //prune out leaves
   if (create_nonleaves){
-    Timer t_shortcut_pleaves("Unoptimized_shortcut_pruneleaves");
-    t_shortcut_pleaves.start();
+    TAU_START(Unoptimized_shortcut_pruneleaves);
     *nonleaves = new Vector<int>(p.len, *p.wrld, *p.sr);
     //set nonleaves[i] = max_j p[j], i.e. set nonleaves[i] = 1 if i has child, i.e. is nonleaf
     for (int64_t i=0; i<npairs; i++){
@@ -112,11 +108,11 @@ void shortcut(Vector<int> & p, Vector<int> & q, Vector<int> & rec_p, Vector<int>
     (*nonleaves)->write(npairs, loc_pairs);
     (*nonleaves)->operator[]("i") = (*nonleaves)->operator[]("i")*p["i"];
     (*nonleaves)->sparsify();
-    t_shortcut_pleaves.stop();
+    TAU_STOP(Unoptimized_shortcut_pruneleaves);
   }
    
   delete [] loc_pairs;
-  t_shortcut.stop();
+  TAU_STOP(Unoptimized_shortcut);
 }
 
 // p[i] = rec_p[q[i]]
@@ -128,8 +124,7 @@ void shortcut2(Vector<int> & p, Vector<int> & q, Vector<int> & rec_p, int sc2, W
     return;
   }
 
-  Timer t_shortcut2("Optimized_shortcut");
-  t_shortcut2.start();
+  TAU_START(Optimized_shortcut);
   
   int64_t rec_p_npairs;
   Pair<int> * rec_p_loc_pairs;
@@ -177,10 +172,9 @@ void shortcut2(Vector<int> & p, Vector<int> & q, Vector<int> & rec_p, int sc2, W
       remote_pairs[i].k = q_loc_pairs[nontriv_index].d;
     }
   
-    Timer t_shortcut2_read("Optimized_shortcut_read");
-    t_shortcut2_read.start();
+    TAU_START(Optimized_shortcut_read);
     rec_p.read(*loc_nontriv_num, remote_pairs); //obtains rec_p[q[i]]
-    t_shortcut2_read.stop();
+    TAU_STOP(Optimized_shortcut_read);
     for(int64_t i = 0; i < *loc_nontriv_num; i++) {
       nontriv_loc_pairs[i].d = remote_pairs[i].d;
     }
@@ -189,11 +183,10 @@ void shortcut2(Vector<int> & p, Vector<int> & q, Vector<int> & rec_p, int sc2, W
       int64_t nontriv_index = nontriv_loc_indices[i];
       q_loc_pairs[nontriv_index].d = remote_pairs[i].d; // p[i] = rec_p[q[i]]
     }
-  
-    Timer t_shortcut2_write("Optimized_shortcut_write");
-    t_shortcut2_write.start();
+ 
+    TAU_START(Optimized_shortcut_write); 
     p.write(*loc_nontriv_num, nontriv_loc_pairs); //enter data into p[i]
-    t_shortcut2_write.stop();
+    TAU_STOP(Optimized_shortcut_write); 
     
     delete [] remote_pairs;
     delete [] global_roots;
@@ -205,25 +198,22 @@ void shortcut2(Vector<int> & p, Vector<int> & q, Vector<int> & rec_p, int sc2, W
     for (int64_t i=0; i<q_npairs; i++) {
       remote_pairs[i].k = q_loc_pairs[i].d;
     }
-    Timer t_shortcut_read("Unoptimized_shortcut_Orread");
-    t_shortcut_read.start();
+    TAU_START(Unoptimized_shortcut_Orread);
     rec_p.read(q_npairs, remote_pairs); //obtains rec_p[q[i]]
-    t_shortcut_read.stop();
+    TAU_STOP(Unoptimized_shortcut_Orread);
     for (int64_t i=0; i<q_npairs; i++){
       q_loc_pairs[i].d = remote_pairs[i].d; //p[i] = rec_p[q[i]]
     }
-    Timer t_shortcut_write("Unoptimized_shortcut_Owrite");
-    t_shortcut_write.start();
+    TAU_START(Unoptimized_shortcut_Owrite);
     p.write(q_npairs, q_loc_pairs); //enter data into p[i]
-    t_shortcut_write.stop();
+    TAU_STOP(Unoptimized_shortcut_Owrite);
 
     delete [] remote_pairs;
   }
   
   //prune out leaves
   if (create_nonleaves) {
-    Timer t_shortcut_pleaves("Unoptimized_shortcut_Opruneleaves");
-    t_shortcut_pleaves.start();
+    TAU_START(Unoptimized_shortcut_Opruneleaves);
     *nonleaves = new Vector<int>(p.len, *p.wrld, *p.sr); //set nonleaves[i] = max_j p[j], i.e. set nonleaves[i] = 1 if i has child, i.e. is nonleaf
     for (int64_t i=0; i<q_npairs; i++){
       q_loc_pairs[i].k = q_loc_pairs[i].d;
@@ -233,9 +223,9 @@ void shortcut2(Vector<int> & p, Vector<int> & q, Vector<int> & rec_p, int sc2, W
     (*nonleaves)->write(q_npairs, q_loc_pairs);
     (*nonleaves)->operator[]("i") = (*nonleaves)->operator[]("i")*p["i"];
     (*nonleaves)->sparsify();
-    t_shortcut_pleaves.stop();
+    TAU_STOP(Unoptimized_shortcut_Opruneleaves);
   }
-  t_shortcut2.stop();
+  TAU_STOP(Optimized_shortcut);
 
   if (delete_p)
     delete [] q_loc_pairs;
@@ -320,8 +310,7 @@ void create_nontriv_loc_indices(int64_t *& nontriv_loc_indices, int64_t * loc_no
 // return B where B[i,j] = A[p[i],p[j]], or if P is P[i,j] = p[i], compute B = P^T A P
 template<typename T>
 Matrix<T>* PTAP(Matrix<T>* A, Vector<int>* p){
-  Timer t_ptap("CONNECTIVITY_PTAP");
-  t_ptap.start();
+  TAU_START(CONNECTIVITY_PTAP);
   int np = p->wrld->np;
   int64_t n = p->len;
   Pair<int> * pprs;
@@ -358,7 +347,7 @@ Matrix<T>* PTAP(Matrix<T>* A, Vector<int>* p){
   Matrix<T> * PTAP = new Matrix<T>(n, n, SP*(A->is_sparse), *A->wrld, *A->sr);
   PTAP->write(nprs, A_prs);
   delete [] A_prs;
-  t_ptap.stop();
+  TAU_STOP(CONNECTIVITY_PTAP);
   return PTAP;
 }
 template Matrix<int>* PTAP<int>(Matrix<int>* A, Vector<int>* p);

--- a/ctf/config.mk
+++ b/ctf/config.mk
@@ -1,15 +1,14 @@
-CTFDIR    =
-MPI_DIR   =
-CXX       = mpicxx -cxx=g++
-OPTS      = -O0 -g
-#CXXFLAGS  = -std=c++0x -fopenmp $(OPTS) -Wall -DPROFILE -DPMPI -DMPIIO
-CXXFLAGS  = -std=c++0x $(OPTS) -Wall -Wno-format -DPMPI -DMPIIO
-INCLUDES  = -I$(CTFDIR)/include
-LIBS      = -L$(CTFDIR)/lib -lctf -lblas generator/libgraph_generator_mpi.a -llapack -lblas 
-#LIBS      = -lctf -lblas generator/libgraph_generator_mpi.a -llapack -lblas 
-DEFS      =
-CUDA_ARCH = sm_37
-NVCC      = $(CXX)
-NVCCFLAGS = $(CXXFLAGS)
+CTF_DIR     = $(HOME)/ctf_rava/ctf
+CRITTER_DIR = $(HOME)/critter
+CXX         = mpicxx
+OPTS        = -g -Wall -O3 -std=c++14 -mkl=parallel -xMIC-AVX512
+CXXFLAGS    = $(OPTS) -Wall -Wno-format -DMPIIO -DCRITTER
+INCLUDES    = -I$(CRITTER_DIR)/src -I$(CTF_DIR)/include
+LIB_PATH    = -L$(CRITTER_DIR)/lib -L$(CTF_DIR)/lib -L/opt/intel/compilers_and_libraries_2017.4.196/linux/mkl/lib/intel64 -Wl,--no-as-needed
+LIBS        = -lcritter -lctf generator/libgraph_generator_mpi.a -lmkl_scalapack_lp64 -lmkl_gf_lp64 -lmkl_intel_thread -lmkl_core -lmkl_blacs_intelmpi_lp64 -lmkl_def -liomp5 -lpthread -lm -ldl
+DEFS        =
+CUDA_ARCH   = sm_37
+NVCC        = $(CXX)
+NVCCFLAGS   = $(CXXFLAGS)
 
 

--- a/ctf/connectivity.cxx
+++ b/ctf/connectivity.cxx
@@ -36,7 +36,7 @@ Matrix<int>* pMatrix(Vector<int>* p, World* world)
 
 // return B where B[i,j] = A[p[i],p[j]], or if P is P[i,j] = p[i], compute B = P^T A P
 Matrix<int>* PTAP(Matrix<int>* A, Vector<int>* p){
-  TAU_START(CONNECTIVITY_PTAP);
+  TAU_FSTART(CONNECTIVITY_PTAP);
   int np = p->wrld->np;
   int64_t n = p->len;
   Pair<int> * pprs;
@@ -73,7 +73,7 @@ Matrix<int>* PTAP(Matrix<int>* A, Vector<int>* p){
   Matrix<int> * PTAP = new Matrix<int>(n, n, SP*(A->is_sparse), *A->wrld, *A->sr);
   PTAP->write(nprs, A_prs);
   delete [] A_prs;
-  TAU_STOP(CONNECTIVITY_PTAP);
+  TAU_FSTOP(CONNECTIVITY_PTAP);
   return PTAP;
 }
 
@@ -81,12 +81,12 @@ Matrix<int>* PTAP(Matrix<int>* A, Vector<int>* p){
 //recursive projection based algorithm
 Vector<int>* supervertex_matrix(int n, Matrix<int>* A, Vector<int>* p, World* world, int sc2)
 {
-  TAU_START(CONNECTIVITY_Relaxation);
+  TAU_FSTART(CONNECTIVITY_Relaxation);
   //relax all edges
   auto q = new Vector<int>(n, SP*p->is_sparse, *world, MAX_TIMES_SR);
   (*q)["i"] = (*p)["i"];
   (*q)["i"] += (*A)["ij"] * (*p)["j"];
-  TAU_STOP(CONNECTIVITY_Relaxation);
+  TAU_FSTOP(CONNECTIVITY_Relaxation);
   Vector<int> * nonleaves;
   //check for convergence
   int64_t diff = are_vectors_different(*q, *p);
@@ -123,9 +123,9 @@ Vector<int>* hook_matrix(int n, Matrix<int> * A, World* world)
   while (are_vectors_different(*p, *prev)) {
     (*prev)["i"] = (*p)["i"];
     auto q = new Vector<int>(n, *world, MAX_TIMES_SR);
-    TAU_START(CONNECTIVITY_Relaxation);
+    TAU_FSTART(CONNECTIVITY_Relaxation);
     (*q)["i"] = (*A)["ij"] * (*p)["j"];
-    TAU_STOP(CONNECTIVITY_Relaxation);
+    TAU_FSTOP(CONNECTIVITY_Relaxation);
     auto r = new Vector<int>(n, *world, MAX_TIMES_SR);
     max_vector(*r, *p, *q);
     //auto P = pMatrix(p, world);

--- a/ctf/connectivity.cxx
+++ b/ctf/connectivity.cxx
@@ -36,8 +36,7 @@ Matrix<int>* pMatrix(Vector<int>* p, World* world)
 
 // return B where B[i,j] = A[p[i],p[j]], or if P is P[i,j] = p[i], compute B = P^T A P
 Matrix<int>* PTAP(Matrix<int>* A, Vector<int>* p){
-  Timer t_ptap("CONNECTIVITY_PTAP");
-  t_ptap.start();
+  TAU_START(CONNECTIVITY_PTAP);
   int np = p->wrld->np;
   int64_t n = p->len;
   Pair<int> * pprs;
@@ -74,7 +73,7 @@ Matrix<int>* PTAP(Matrix<int>* A, Vector<int>* p){
   Matrix<int> * PTAP = new Matrix<int>(n, n, SP*(A->is_sparse), *A->wrld, *A->sr);
   PTAP->write(nprs, A_prs);
   delete [] A_prs;
-  t_ptap.stop();
+  TAU_STOP(CONNECTIVITY_PTAP);
   return PTAP;
 }
 
@@ -82,13 +81,12 @@ Matrix<int>* PTAP(Matrix<int>* A, Vector<int>* p){
 //recursive projection based algorithm
 Vector<int>* supervertex_matrix(int n, Matrix<int>* A, Vector<int>* p, World* world, int sc2)
 {
-  Timer t_relax("CONNECTIVITY_Relaxation");
-  t_relax.start();
+  TAU_START(CONNECTIVITY_Relaxation);
   //relax all edges
   auto q = new Vector<int>(n, SP*p->is_sparse, *world, MAX_TIMES_SR);
   (*q)["i"] = (*p)["i"];
   (*q)["i"] += (*A)["ij"] * (*p)["j"];
-  t_relax.stop();
+  TAU_STOP(CONNECTIVITY_Relaxation);
   Vector<int> * nonleaves;
   //check for convergence
   int64_t diff = are_vectors_different(*q, *p);
@@ -125,10 +123,9 @@ Vector<int>* hook_matrix(int n, Matrix<int> * A, World* world)
   while (are_vectors_different(*p, *prev)) {
     (*prev)["i"] = (*p)["i"];
     auto q = new Vector<int>(n, *world, MAX_TIMES_SR);
-    Timer t_relax("CONNECTIVITY_Relaxation");
-    t_relax.start();
+    TAU_START(CONNECTIVITY_Relaxation);
     (*q)["i"] = (*A)["ij"] * (*p)["j"];
-    t_relax.stop();
+    TAU_STOP(CONNECTIVITY_Relaxation);
     auto r = new Vector<int>(n, *world, MAX_TIMES_SR);
     max_vector(*r, *p, *q);
     //auto P = pMatrix(p, world);

--- a/ctf/generator/Makefile
+++ b/ctf/generator/Makefile
@@ -1,6 +1,6 @@
 AR = ar
 RANLIB = ranlib
-CC = cc
+CC = mpicxx -cxx=g++
 CFLAGS = -g -Wall -Drestrict=__restrict__ -O3 -DNDEBUG -ffast-math -DGRAPH_GENERATOR_SEQ # -g -pg
 # CFLAGS = -g -Wall -Drestrict=__restrict__
 LDFLAGS = -g # -g -pg

--- a/ctf/generator/Makefile.BFS.mpi
+++ b/ctf/generator/Makefile.BFS.mpi
@@ -1,10 +1,10 @@
 AR = ar
 RANLIB = ranlib
-CC = cc
+CC = mpicc
 CFLAGS = -Wall -Drestrict=__restrict__ -O3 -DNDEBUG -DGRAPH_GENERATOR_MPI -DGRAPHGEN_DISTRIBUTED_MEMORY
 # CFLAGS = -g -Wall -Drestrict= -DGRAPH_GENERATOR_MPI -DGRAPHGEN_DISTRIBUTED_MEMORY # -g -pg
 LDFLAGS =  # -g -pg
-MPICC = CC
+MPICC = mpicxx
 
 
 all: libgraph_generator_mpi.a generator_test_mpi

--- a/ctf/graph_aux.h
+++ b/ctf/graph_aux.h
@@ -1,6 +1,7 @@
 #ifndef __GRAPH_AUX_H__
 #define __GRAPH_AUX_H__
 
+#include "critter.h"
 #include <ctf.hpp>
 #include <float.h>
 #define __STDC_FORMAT_MACROS 1

--- a/ctf/graph_aux.h
+++ b/ctf/graph_aux.h
@@ -1,7 +1,10 @@
 #ifndef __GRAPH_AUX_H__
 #define __GRAPH_AUX_H__
 
+#ifdef CRITTER
 #include "critter.h"
+#endif
+
 #include <ctf.hpp>
 #include <float.h>
 #define __STDC_FORMAT_MACROS 1

--- a/ctf/graph_gen.cxx
+++ b/ctf/graph_gen.cxx
@@ -5,10 +5,9 @@ uint64_t gen_graph(int scale, int edgef, uint64_t seed, uint64_t **edges) {
 
   uint64_t nedges;
   double   initiator[4] = {.57, .19, .19, .05};
-  CTF::Timer tmrg("gen_graph");
-  tmrg.start();
+  TAU_START(gen_graph);
   make_graph(scale, (((int64_t)1)<<scale)*edgef, seed, seed+1, initiator, (int64_t *)&nedges, (int64_t **)edges);
-  tmrg.stop();
+  TAU_STOP(gen_graph);
 
   return nedges;
 }

--- a/ctf/mst_templates.cxx
+++ b/ctf/mst_templates.cxx
@@ -82,8 +82,7 @@ inline CTF::Vector<int> * get_nonleaves<int>(CTF::Vector<int> & p, int64_t npair
 template <typename T, typename S>
 void shortcut(CTF::Vector<T> & p, CTF::Vector<S> & q, CTF::Vector<T> & rec_p, CTF::Vector<int> ** nonleaves, bool create_nonleaves)
 {
-  CTF::Timer t_shortcut("CONNECTIVITY_Shortcut");
-  t_shortcut.start();
+  TAU_FSTART(CONNECTIVITY_Shortcut);
   int64_t npairs;
   CTF::Pair<S> * loc_pairs;
   if (q.is_sparse){
@@ -100,10 +99,9 @@ void shortcut(CTF::Vector<T> & p, CTF::Vector<S> & q, CTF::Vector<T> & rec_p, CT
   }*/
   remote_pairs_k(remote_pairs, loc_pairs, npairs); // remote_pairs[i].k = loc_pairs[i].d, overloaded for dtypes
   
-  CTF::Timer t_shortcut_read("CONNECTIVITY_Shortcut_read");
-  t_shortcut_read.start();
+  TAU_FSTART(CONNECTIVITY_Shortcut_read);
   rec_p.read(npairs, remote_pairs); //obtains rec_p[q[i]]
-  t_shortcut_read.stop();
+  TAU_FSTOP(CONNECTIVITY_Shortcut_read);
  
   rec_p.print(); 
   CTF::Pair<T> * updated_loc_pairs = new CTF::Pair<T>[npairs];
@@ -122,7 +120,7 @@ void shortcut(CTF::Vector<T> & p, CTF::Vector<S> & q, CTF::Vector<T> & rec_p, CT
   
   delete [] loc_pairs;
   delete [] updated_loc_pairs;
-  t_shortcut.stop();
+  TAU_FSTOP(CONNECTIVITY_Shortcut);
 }
 
 template <typename dtype>

--- a/ctf/test_connectivity.cxx
+++ b/ctf/test_connectivity.cxx
@@ -165,15 +165,14 @@ void run_connectivity(Matrix<int>* A, int64_t matSize, World *w, int batch, int 
   auto pg = new Vector<int>(matSize, *w, MAX_TIMES_SR);
   init_pvector(pg);
   Scalar<int64_t> count(*w);
-  Timer_epoch thm("hook_matrix");
-  thm.begin();
+  TAU_START(hook_matrix);
   stime = MPI_Wtime();
   auto hm = hook_matrix(matSize, A, w);
   etime = MPI_Wtime();
   if (w->rank == 0) {
     printf("Time for hook_matrix(): %1.2lf\n", (etime - stime));
   }
-  thm.end();
+  TAU_STOP(hook_matrix);
   count[""] = Function<int,int,int64_t>([](int a, int b){ return (int64_t)(a==b); })((*pg)["i"], hm->operator[]("i"));
   int64_t cnt = count.get_val();
   if (w->rank == 0) {
@@ -182,8 +181,7 @@ void run_connectivity(Matrix<int>* A, int64_t matSize, World *w, int batch, int 
 
   auto p = new Vector<int>(matSize, *w, MAX_TIMES_SR);
   init_pvector(p);
-  Timer_epoch tsv("super_vertex");
-  tsv.begin();
+  TAU_START(super_vertex);
   Vector<int>* sv;
   stime = MPI_Wtime();
   if (batch == 1) {
@@ -209,7 +207,7 @@ void run_connectivity(Matrix<int>* A, int64_t matSize, World *w, int batch, int 
   if (w->rank == 0) {
     printf("Time for supervertex_matrix(): %1.2lf\n", (etime - stime));
   }
-  tsv.end();
+  TAU_STOP(super_vertex);
   count[""] = Function<int,int,int64_t>([](int a, int b){ return (int64_t)(a==b); })((*pg)["i"], sv->operator[]("i")); // TODO: returning incorrect result on multiple processes
   cnt = count.get_val();
 

--- a/ctf/test_mst.cxx
+++ b/ctf/test_mst.cxx
@@ -464,12 +464,11 @@ void run_mst(Matrix<wht>* A, int64_t matSize, World *w, int batch, int sc2, int 
   matSize = A->nrow; // Quick fix to avoid change in i/p matrix size after preprocessing
   Vector<EdgeExt>* mult_mst;
   if (run_multilinear) {
-    Timer_epoch tmh("multilinear_hook");
-    tmh.begin();
+    TAU_START(multilinear_hook);
     stime = MPI_Wtime();
     mult_mst = multilinear_hook(A, w, sc2);
     etime = MPI_Wtime();
-    tmh.end();
+    TAU_STOP(multilinear_hook);
     if (w->rank == 0) {
       printf("multilinear mst done in %1.2lf\n", (etime - stime));
     }
@@ -480,13 +479,13 @@ void run_mst(Matrix<wht>* A, int64_t matSize, World *w, int batch, int sc2, int 
     s[""] = sum_weights((*mult_mst)["i"]);
     if (w->rank == 0)
     	printf("weight of mst: %d\n", s.get_val());
+    std::cout << "there\n";
   }
   /*
   Vector<EdgeExt> * hm;
   int run_hook = 0;
   if (run_hook) {
-    Timer_epoch thm("hook_matrix");
-    thm.begin();
+    TAU_START(hook_matrix);
     stime = MPI_Wtime();
     hm = hook_matrix(A, w);
     etime = MPI_Wtime();
@@ -496,7 +495,7 @@ void run_mst(Matrix<wht>* A, int64_t matSize, World *w, int batch, int sc2, int 
     }
     hm->print();
     printf("\n");
-    //thm.end();
+    TAU_STOP(hook_matrix);
   }
   if (run_multilinear && run_hook) {
     auto res = compare_mst(hm, mult_mst);

--- a/ctf/test_mst.cxx
+++ b/ctf/test_mst.cxx
@@ -479,7 +479,6 @@ void run_mst(Matrix<wht>* A, int64_t matSize, World *w, int batch, int sc2, int 
     s[""] = sum_weights((*mult_mst)["i"]);
     if (w->rank == 0)
     	printf("weight of mst: %d\n", s.get_val());
-    std::cout << "there\n";
   }
   /*
   Vector<EdgeExt> * hm;
@@ -557,7 +556,6 @@ int main(int argc, char** argv)
 
   int k;
   MPI_Init(&argc, &argv);
-  auto w = new World(argc, argv);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &np);
   {


### PR DESCRIPTION
I have incorporated the necessary changes to allow for utilizing either CTF_Timer or critter.
Each intercepts TAU_FSTART/TAU_FSTOP symbols, which I have replaced the explicit CTF_Timer instances with.